### PR TITLE
Prepare to Rector next 2.0 with PHPStan 2 and PHPParser 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.0",
         "php-static-analysis/attributes": "^0.3.1 || dev-main",
         "php-static-analysis/node-visitor": "^0.3.1 || dev-main",
         "rector/rector": "dev-main as 1.2.10"

--- a/composer.json
+++ b/composer.json
@@ -26,16 +26,16 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.2",
         "php-static-analysis/attributes": "^0.3.1 || dev-main",
         "php-static-analysis/node-visitor": "^0.3.1 || dev-main",
-        "rector/rector": "^0.19 || ^1.0"
+        "rector/rector": "dev-main as 1.2.10"
     },
     "require-dev": {
         "php-static-analysis/phpstan-extension": "dev-main",
         "php-static-analysis/psalm-plugin": "dev-main",
         "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan": "^1.8",
+        "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^9.0",
         "symplify/easy-coding-standard": "^12.1",
         "vimeo/psalm": "^5",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": ">=8.0",
         "php-static-analysis/attributes": "^0.3.1 || dev-main",
         "php-static-analysis/node-visitor": "^0.3.1 || dev-main",
-        "rector/rector": "2.0.0rc1"
+        "rector/rector": "~2.0.0"
     },
     "require-dev": {
         "php-static-analysis/phpstan-extension": "dev-main",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": ">=8.0",
         "php-static-analysis/attributes": "^0.3.1 || dev-main",
         "php-static-analysis/node-visitor": "^0.3.1 || dev-main",
-        "rector/rector": "dev-main as 1.2.10"
+        "rector/rector": "2.0.0rc1"
     },
     "require-dev": {
         "php-static-analysis/phpstan-extension": "dev-main",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,3 +6,6 @@ parameters:
     excludePaths:
         - tests/Fixture/*
         - tests/SpecialFixture/*
+
+    ignoreErrors:
+        - '#::provideMinPhpVersion\(\) never returns \d+ so it can be removed from the return type#'

--- a/src/AnnotationsToAttributesRector.php
+++ b/src/AnnotationsToAttributesRector.php
@@ -207,6 +207,7 @@ CODE_SAMPLE
     #[Param(node: 'Stmt\Class_|Stmt\ClassConst|Stmt\ClassMethod|Stmt\Function_|Stmt\Interface_|Stmt\Property|Stmt\Trait_')]
     public function refactor(Node $node): ?Node
     {
+        $hasChanged = false;
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
 
         $attributeGroups = [];
@@ -215,6 +216,7 @@ CODE_SAMPLE
         }
 
         if ($attributeGroups !== []) {
+            $hasChanged = true;
             $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
 
             $this->attributeGroupNamedArgumentManipulator->decorate($attributeGroups);
@@ -243,6 +245,8 @@ CODE_SAMPLE
                                     $arg->name = null;
                                     $parameterAttributeGroups = [new AttributeGroup([$attribute])];
                                     $parameter->attrGroups = array_merge($parameter->attrGroups, $parameterAttributeGroups);
+
+                                    $hasChanged = true;
                                 }
                             }
                         }
@@ -250,6 +254,7 @@ CODE_SAMPLE
                 }
                 if ($attributeGroup->attrs === []) {
                     unset($attributeGroups[$attrKey]);
+                    $hasChanged = true;
                 }
             }
         }
@@ -266,6 +271,8 @@ CODE_SAMPLE
 
                             $this->attributeGroupNamedArgumentManipulator->decorate($useAttributeGroups);
                             $attributeGroups = array_merge($attributeGroups, $useAttributeGroups);
+
+                            $hasChanged = true;
                         }
                     }
                 }
@@ -274,6 +281,11 @@ CODE_SAMPLE
 
         if ($attributeGroups !== []) {
             $node->attrGroups = array_merge($node->attrGroups, $attributeGroups);
+            $hasChanged = true;
+        }
+
+        if (! $hasChanged) {
+            return null;
         }
 
         return $node;


### PR DESCRIPTION
Rector is upgrading to PHPStan 2 and PHPParser 5 at PR:

- https://github.com/rectorphp/rector-src/pull/6431

this PR upgrade for compatiblity syntax.